### PR TITLE
feat: improve price history modal UX and fix calculation bugs

### DIFF
--- a/src/features/offers/guest/components/OfferCardFlex.tsx
+++ b/src/features/offers/guest/components/OfferCardFlex.tsx
@@ -5,7 +5,7 @@ import {showToast} from "../../../../lib/ToastContainer.tsx";
 import {selectedComputerAtom} from "../../../computers/atoms/computerAtom.tsx";
 import {useUpdateOffersToComputer} from "../../../offersUpdates/admin/hooks/useUpdateOffersToComputer.ts";
 import {validateCompatibility} from "../../../computers/hooks/validateCompatibility.ts";
-import {ImageOff} from "lucide-react";
+import {ImageOff, TrendingUp} from "lucide-react";
 import {ShopImageComponent} from "./ShopImageComponent.tsx";
 import {userAtom} from "../../../auth/atoms/userAtom.tsx";
 import {guestComputersAtom} from "../../../computers/atoms/guestComputersAtom.ts";
@@ -231,6 +231,14 @@ const OfferCardFlex = ({ offer } : Props) => {
                             {offer.price.toLocaleString("pl-PL")} zł
                         </span>
 
+                        <button
+                            onClick={(e) => { e.stopPropagation(); setShowModal(true); }}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-dark-surface2 text-dark-muted hover:text-dark-text transition-all text-xs font-semibold"
+                            aria-label="Historia cen"
+                        >
+                            <TrendingUp size={14} />
+                            Historia
+                        </button>
                         <button
                             onClick={(e) => { e.stopPropagation(); (user ? updateComputer : updateComputerGuest)(); }}
                             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-dark-accent/15 text-dark-accent hover:bg-dark-accent hover:text-white transition-all text-xs font-semibold"

--- a/src/features/offers/guest/components/OfferCardGrid.tsx
+++ b/src/features/offers/guest/components/OfferCardGrid.tsx
@@ -1,4 +1,4 @@
-import {ImageOff, Plus} from "lucide-react";
+import {ImageOff, Plus, TrendingUp} from "lucide-react";
 import type {ComponentOffer} from "../../../../shared/dtos/OfferBase.ts";
 import {showToast} from "../../../../lib/ToastContainer.tsx";
 import {validateCompatibility} from "../../../computers/hooks/validateCompatibility.ts";
@@ -112,6 +112,10 @@ const renderConditionBadge = (condition: string) => {
                 <ImageOff className="text-dark-border w-10 h-10" strokeWidth={1.5} />
             )}
             {renderConditionBadge(offer.condition)}
+            <div className="absolute bottom-1 left-1 flex items-center gap-0.5 bg-dark-bg/70 backdrop-blur-sm text-dark-muted text-[9px] px-1.5 py-0.5 rounded-md">
+                <TrendingUp size={9} />
+                <span>Historia cen</span>
+            </div>
         </div>
 
         <div className="p-2 text-center flex-1 flex items-center justify-center min-h-[3rem]">

--- a/src/features/offers/guest/components/PriceHistoryModal.tsx
+++ b/src/features/offers/guest/components/PriceHistoryModal.tsx
@@ -10,6 +10,7 @@ import {
     CartesianGrid,
     Tooltip,
     Legend,
+    ReferenceLine,
 } from "recharts";
 import { useGetComponentMinMax } from "../hooks/useGetComponentMinMax.ts";
 import { useGetMonthlyAvgPrices } from "../hooks/useGetMonthlyAvgPrices.ts";
@@ -21,16 +22,15 @@ interface Props {
     onClose: () => void;
 }
 
-
 const SHOP_PALETTE = [
-    "#4f8ef7", // blue
-    "#f59e0b", // amber
-    "#22c55e", // green
-    "#a78bfa", // violet
-    "#f43f5e", // rose
-    "#06b6d4", // cyan
-    "#fb923c", // orange
-    "#e879f9", // fuchsia
+    "#4f8ef7",
+    "#f59e0b",
+    "#22c55e",
+    "#a78bfa",
+    "#f43f5e",
+    "#06b6d4",
+    "#fb923c",
+    "#e879f9",
 ];
 
 const shopColors: Record<string, string> = {
@@ -59,12 +59,17 @@ const CustomTooltip = ({ active, payload, label }: any) => {
 };
 
 type ViewMode = "overall" | "by-shop";
+type TimeRange = "3M" | "6M" | "1Y";
+
+const RANGE_MAP: Record<TimeRange, number> = { "3M": 3, "6M": 6, "1Y": 12 };
 
 export const PriceHistoryModal = ({ offer, onClose }: Props) => {
     const [viewMode, setViewMode] = useState<ViewMode>("overall");
+    const [timeRange, setTimeRange] = useState<TimeRange>("1Y");
 
-    const { data: minMaxData } = useGetComponentMinMax(offer.id!);
-    const { data: monthlyAvgPrices } = useGetMonthlyAvgPrices(offer.id!);
+    const { data: minMaxData, isLoading: minMaxLoading } = useGetComponentMinMax(offer.id!);
+    const { data: monthlyAvgPrices, isLoading: pricesLoading } = useGetMonthlyAvgPrices(offer.id!);
+    const isLoading = minMaxLoading || pricesLoading;
 
     const chartOverall = useMemo(() => {
         if (!monthlyAvgPrices?.length) return [];
@@ -95,25 +100,28 @@ export const PriceHistoryModal = ({ offer, onClose }: Props) => {
             .map(([month, shops]) => ({ date: MONTH_NAMES[Number(month) - 1], ...shops }));
     }, [monthlyAvgPrices]);
 
+    const filteredOverall = chartOverall.slice(-RANGE_MAP[timeRange]);
+    const filteredByShop = chartByShop.slice(-RANGE_MAP[timeRange]);
+
     const availableShops = useMemo(
         () => monthlyAvgPrices?.map((s) => s.shop) ?? [],
         [monthlyAvgPrices]
     );
 
-    const lastMonthPrice = chartOverall.at(-1)?.price ?? 0;
-    const prevMonthPrice = chartOverall.at(-2)?.price ?? 0;
-    const diff = lastMonthPrice - prevMonthPrice;
-    const diffPct = prevMonthPrice ? Math.round((diff / prevMonthPrice) * 100) : 0;
+    const lastMonthPrice = filteredOverall.at(-1)?.price ?? 0;
+    const firstMonthPrice = filteredOverall.at(0)?.price ?? 0;
+    const diff = lastMonthPrice - firstMonthPrice;
+    const diffPct = firstMonthPrice ? Math.round((diff / firstMonthPrice) * 100) : 0;
+
+    const hasData = filteredOverall.length > 0;
 
     return (
         <div
             className="fixed inset-0 z-[200] flex items-center justify-center p-4"
             onClick={onClose}
         >
-            {/* Backdrop */}
             <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
 
-            {/* Modal */}
             <div
                 className="relative bg-dark-surface border border-dark-border rounded-2xl shadow-2xl w-full max-w-2xl overflow-hidden"
                 onClick={(e) => e.stopPropagation()}
@@ -142,30 +150,40 @@ export const PriceHistoryModal = ({ offer, onClose }: Props) => {
                     </div>
                     <div className="px-5 py-4">
                         <p className="text-[11px] text-dark-muted uppercase tracking-wide mb-1">Min / Max (rok)</p>
-                        <p className="text-sm font-semibold text-dark-text">
-                            <span className="text-green-400">{minMaxData?.min.toLocaleString("pl-PL")}</span>
-                            <span className="text-dark-muted mx-1">/</span>
-                            <span className="text-red-400">{minMaxData?.max.toLocaleString("pl-PL")}</span>
-                            <span className="text-dark-muted text-xs ml-1">zł</span>
-                        </p>
+                        {isLoading ? (
+                            <div className="h-5 bg-dark-surface2 rounded animate-pulse w-24" />
+                        ) : (
+                            <p className="text-sm font-semibold text-dark-text">
+                                <span className="text-green-400">{minMaxData?.min.toLocaleString("pl-PL")}</span>
+                                <span className="text-dark-muted mx-1">/</span>
+                                <span className="text-red-400">{minMaxData?.max.toLocaleString("pl-PL")}</span>
+                                <span className="text-dark-muted text-xs ml-1">zł</span>
+                            </p>
+                        )}
                     </div>
                     <div className="px-5 py-4">
-                        <p className="text-[11px] text-dark-muted uppercase tracking-wide mb-1">Zmiana (rok)</p>
-                        <div className="flex items-center gap-1.5">
-                            {diff < 0
-                                ? <TrendingDown size={16} className="text-green-400" />
-                                : diff > 0
-                                    ? <TrendingUp size={16} className="text-red-400" />
-                                    : <Minus size={16} className="text-dark-muted" />
-                            }
-                            <span className={`text-sm font-bold ${diff < 0 ? "text-green-400" : diff > 0 ? "text-red-400" : "text-dark-muted"}`}>
-                                {diff > 0 ? "+" : ""}{diff.toLocaleString("pl-PL")} zł ({diffPct}%)
-                            </span>
-                        </div>
+                        <p className="text-[11px] text-dark-muted uppercase tracking-wide mb-1">Zmiana ({timeRange})</p>
+                        {isLoading ? (
+                            <div className="h-5 bg-dark-surface2 rounded animate-pulse w-20" />
+                        ) : hasData ? (
+                            <div className="flex items-center gap-1.5">
+                                {diff < 0
+                                    ? <TrendingDown size={16} className="text-green-400" />
+                                    : diff > 0
+                                        ? <TrendingUp size={16} className="text-red-400" />
+                                        : <Minus size={16} className="text-dark-muted" />
+                                }
+                                <span className={`text-sm font-bold ${diff < 0 ? "text-green-400" : diff > 0 ? "text-red-400" : "text-dark-muted"}`}>
+                                    {diff > 0 ? "+" : ""}{diff.toLocaleString("pl-PL")} zł ({diffPct}%)
+                                </span>
+                            </div>
+                        ) : (
+                            <span className="text-dark-muted text-sm">—</span>
+                        )}
                     </div>
                 </div>
 
-                {/* View toggle */}
+                {/* Controls row */}
                 <div className="flex items-center gap-2 px-6 pt-4">
                     <button
                         onClick={() => setViewMode("overall")}
@@ -187,51 +205,92 @@ export const PriceHistoryModal = ({ offer, onClose }: Props) => {
                     >
                         Według sklepów
                     </button>
+
+                    <div className="flex-1" />
+
+                    {(["3M", "6M", "1Y"] as TimeRange[]).map((r) => (
+                        <button
+                            key={r}
+                            onClick={() => setTimeRange(r)}
+                            className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${
+                                timeRange === r
+                                    ? "bg-dark-surface2 text-white"
+                                    : "text-dark-muted hover:text-dark-text"
+                            }`}
+                        >
+                            {r}
+                        </button>
+                    ))}
                 </div>
 
-                {/* Chart */}
-                <div className="px-4 pb-5 pt-3">
-                    <ResponsiveContainer width="100%" height={240}>
-                        {viewMode === "overall" ? (
-                            <LineChart data={chartOverall} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
-                                <CartesianGrid strokeDasharray="3 3" stroke="#252a3a" />
-                                <XAxis dataKey="date" tick={{ fill: "#6b7280", fontSize: 11 }} axisLine={false} tickLine={false} />
-                                <YAxis tick={{ fill: "#6b7280", fontSize: 11 }} axisLine={false} tickLine={false} width={60}
-                                    tickFormatter={(v) => `${v} zł`} />
-                                <Tooltip content={<CustomTooltip />} />
-                                <Line
-                                    type="monotone"
-                                    dataKey="price"
-                                    name="Cena"
-                                    stroke="#4f8ef7"
-                                    strokeWidth={2.5}
-                                    dot={{ fill: "#4f8ef7", r: 3, strokeWidth: 0 }}
-                                    activeDot={{ r: 5, fill: "#4f8ef7" }}
-                                />
-                            </LineChart>
-                        ) : (
-                            <LineChart data={chartByShop} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
-                                <CartesianGrid strokeDasharray="3 3" stroke="#252a3a" />
-                                <XAxis dataKey="date" tick={{ fill: "#6b7280", fontSize: 11 }} axisLine={false} tickLine={false} />
-                                <YAxis tick={{ fill: "#6b7280", fontSize: 11 }} axisLine={false} tickLine={false} width={60}
-                                    tickFormatter={(v) => `${v} zł`} />
-                                <Tooltip content={<CustomTooltip />} />
-                                <Legend wrapperStyle={{ fontSize: 12, color: "#6b7280", paddingTop: 8 }} />
-                                {availableShops.map((shop, i) => (
-                                    <Line
-                                        key={shop}
-                                        type="monotone"
-                                        dataKey={shop}
-                                        stroke={getShopColor(shop, i)}
-                                        strokeWidth={2}
-                                        dot={{ fill: getShopColor(shop, i), r: 3, strokeWidth: 0 }}
-                                        activeDot={{ r: 5 }}
+                {/* Chart / Skeleton / Empty */}
+                {isLoading ? (
+                    <div className="px-4 pb-5 pt-3 space-y-2 animate-pulse">
+                        <div className="h-4 bg-dark-surface2 rounded w-1/3" />
+                        <div className="h-48 bg-dark-surface2 rounded-xl" />
+                    </div>
+                ) : !hasData ? (
+                    <div className="px-4 pb-10 pt-6 text-center text-dark-muted text-sm">
+                        Brak danych historycznych dla tego komponentu.
+                    </div>
+                ) : (
+                    <div className="px-4 pb-5 pt-3">
+                        <ResponsiveContainer width="100%" height={240}>
+                            {viewMode === "overall" ? (
+                                <LineChart data={filteredOverall} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+                                    <CartesianGrid strokeDasharray="3 3" stroke="#252a3a" />
+                                    <XAxis dataKey="date" tick={{ fill: "#6b7280", fontSize: 11 }} axisLine={false} tickLine={false} />
+                                    <YAxis tick={{ fill: "#6b7280", fontSize: 11 }} axisLine={false} tickLine={false} width={60}
+                                        tickFormatter={(v) => `${v} zł`} />
+                                    <Tooltip content={<CustomTooltip />} />
+                                    <ReferenceLine
+                                        y={offer.price}
+                                        stroke="#4f8ef7"
+                                        strokeDasharray="4 4"
+                                        strokeOpacity={0.5}
+                                        label={{ value: "Ta oferta", fill: "#4f8ef7", fontSize: 10, position: "insideTopRight" }}
                                     />
-                                ))}
-                            </LineChart>
-                        )}
-                    </ResponsiveContainer>
-                </div>
+                                    <Line
+                                        type="monotone"
+                                        dataKey="price"
+                                        name="Cena"
+                                        stroke="#4f8ef7"
+                                        strokeWidth={2.5}
+                                        dot={{ fill: "#4f8ef7", r: 3, strokeWidth: 0 }}
+                                        activeDot={{ r: 5, fill: "#4f8ef7" }}
+                                    />
+                                </LineChart>
+                            ) : (
+                                <LineChart data={filteredByShop} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+                                    <CartesianGrid strokeDasharray="3 3" stroke="#252a3a" />
+                                    <XAxis dataKey="date" tick={{ fill: "#6b7280", fontSize: 11 }} axisLine={false} tickLine={false} />
+                                    <YAxis tick={{ fill: "#6b7280", fontSize: 11 }} axisLine={false} tickLine={false} width={60}
+                                        tickFormatter={(v) => `${v} zł`} />
+                                    <Tooltip content={<CustomTooltip />} />
+                                    <Legend wrapperStyle={{ fontSize: 12, color: "#6b7280", paddingTop: 8 }} />
+                                    <ReferenceLine
+                                        y={offer.price}
+                                        stroke="#4f8ef7"
+                                        strokeDasharray="4 4"
+                                        strokeOpacity={0.5}
+                                        label={{ value: "Ta oferta", fill: "#4f8ef7", fontSize: 10, position: "insideTopRight" }}
+                                    />
+                                    {availableShops.map((shop, i) => (
+                                        <Line
+                                            key={shop}
+                                            type="monotone"
+                                            dataKey={shop}
+                                            stroke={getShopColor(shop, i)}
+                                            strokeWidth={2}
+                                            dot={{ fill: getShopColor(shop, i), r: 3, strokeWidth: 0 }}
+                                            activeDot={{ r: 5 }}
+                                        />
+                                    ))}
+                                </LineChart>
+                            )}
+                        </ResponsiveContainer>
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
- Add time range filter (3M/6M/1Y) to PriceHistoryModal with client-side data slicing
- Fix "Zmiana" stat: now compares first vs last month in selected range (was last vs second-to-last)
- Add loading skeletons (animate-pulse) for stats row and chart area
- Add empty state message when no historical data is available
- Add reference line "Ta oferta" on chart showing current offer price
- Add "Historia cen" label with TrendingUp icon on OfferCardGrid to signal clickability
- Add dedicated "Historia" button with TrendingUp icon in OfferCardFlex next to "Dodaj"